### PR TITLE
Fix formatting in installation command for vllm

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ MERA — независимый открытый проект [Альянса в
 
     ```bash
     pip install pillow
-    pip install -e ."[vllm]"
+    pip install -e ".[vllm]"
     ```
 
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change corrects the syntax for installing the `vllm` extra dependencies using pip. The old installation format was not correct.
